### PR TITLE
Warn about base vs head relationship

### DIFF
--- a/git_explode/exploder.py
+++ b/git_explode/exploder.py
@@ -27,6 +27,10 @@ class GitExploder(object):
         self.base_commit = GitUtils.ref_commit(repo, base)
         self.logger.debug("base commit %s is %s" %
                           (base, GitUtils.commit_summary(self.base_commit)))
+        head_commit = GitUtils.ref_commit(repo, head)
+        merge_base_id = repo.merge_base(self.base_commit.id, head_commit.id)
+        if not merge_base_id or merge_base_id != self.base_commit.id:
+            self.logger.warn("Base commit not ancestor of head, cherry-picks may fail")
         self.head = head
         self.context_lines = context_lines
         self.topic_mgr = TopicManager('topic%d', self.logger)


### PR DESCRIPTION
I inadvertently passed a base commit that was not an ancestory of head and exploded branch could not be cherry-picked cleanly on top of base (because of head..base changes).

pygit2 does not have an equivalent of `git merge-base --is-ancestor`, so use the closes approximation by comparing merge base to base. (Hopefully, the "base" is picked by merge_base function when there are multiple merge bases possible so that this ancestor check is corect.)